### PR TITLE
Update q-learning.py

### DIFF
--- a/q-learning.py
+++ b/q-learning.py
@@ -41,8 +41,12 @@ for i in range(num_episodes):
     
     # The Q-Table learning algorithm
     while not done:
+        try:
+            s = s[0]
+        except TypeError:
+            pass
         a = np.argmax(Q[s,:] + np.random.randn(1,env.action_space.n)*(1./(i+1)))
-        s_, r, done, _ = env.step(a)
+        s_, r, done, _ , _ = env.step(a)
         
         # update Q values
         Q[s,a] = Q[s,a] + lr*(r + num_episodes*np.max(Q[s_,:]) - Q[s,a])


### PR DESCRIPTION
Q[s,:] is causing an issue bcs at first, s is a tuple: s (0, { prob : 1 })  so it has to be mapped at first, then it continues to be s as a single int value. Also, env.step(a) returns 5 elements isntead of 4, where the 5th one is prob